### PR TITLE
Fixed wait so it disposes the process

### DIFF
--- a/src/LclDckr/project.json
+++ b/src/LclDckr/project.json
@@ -1,5 +1,5 @@
 ﻿{
-  "version": "1.0.6-*",
+  "version": "1.0.7-*",
   "description": "A dotnet wrapper around the docker cli.",
   "authors":  ["Syncromatics"],
   "packOptions": {


### PR DESCRIPTION
Breaking Change: WaitForLogEntryAsync will no longer throw it will return false if it fails.