### PR TITLE
Add support for removing images

### DIFF
--- a/src/LclDckr/DockerClient.cs
+++ b/src/LclDckr/DockerClient.cs
@@ -62,6 +62,28 @@ namespace LclDckr
         }
 
         /// <summary>
+        /// Removes a specified Docker image.
+        /// </summary>
+        /// <param name="imageName">The name of the image to remove.</param>
+        /// <param name="tag">The tag of the image to remove.</param>
+        /// <param name="force">Whether to remove image even if in use by one or more containers.</param>
+        /// <returns></returns>
+        public string RemoveImage(string imageName, string tag, bool force = false)
+        {
+            string forceArg = force ? "-f " : "";
+            var args = $"image rm {forceArg}{imageName}";
+            using (var process = GetDockerProcess(args))
+            {
+                process.Start();
+                process.WaitForExit();
+                process.ThrowForError();
+
+                // remove trailing \n
+                return process.StandardOutput.ReadToEnd().TrimEnd();
+            }
+        }
+
+        /// <summary>
         /// Runs the specified image in a new container
         /// </summary>
         /// <param name="imageName"></param>

--- a/src/LclDckr/DockerClient.cs
+++ b/src/LclDckr/DockerClient.cs
@@ -65,10 +65,9 @@ namespace LclDckr
         /// Removes a specified Docker image.
         /// </summary>
         /// <param name="imageName">The name of the image to remove.</param>
-        /// <param name="tag">The tag of the image to remove.</param>
         /// <param name="force">Whether to remove image even if in use by one or more containers.</param>
         /// <returns></returns>
-        public string RemoveImage(string imageName, string tag, bool force = false)
+        public string RemoveImage(string imageName, bool force = false)
         {
             string forceArg = force ? "-f " : "";
             var args = $"image rm {forceArg}{imageName}";


### PR DESCRIPTION
Library consumers could already create images -- add a quick wrapper around `docker image rm` so consumers can be good citizens and clean up after themselves.